### PR TITLE
Fix #1: bemgr create fails with time zones that aren't west of UTC.

### DIFF
--- a/source/bemgr/util.d
+++ b/source/bemgr/util.d
@@ -338,7 +338,7 @@ string createSnapshotWithTime(string dataset)
     import std.format : format;
     import std.process : esfn = escapeShellFileName;
 
-    immutable snapName = format!"%s@bemgr_%s"(dataset, getCurrTimeWithOffset());
+    immutable snapName = format!"%s@bemgr_%s"(dataset, getCurrTimeAsString());
 
     runCmd(format!"zfs snap %s"(esfn(snapName)));
 
@@ -372,7 +372,7 @@ void promote(string dataset)
 
 private:
 
-string getCurrTimeWithOffset()
+string getCurrTimeAsString()
 {
     import core.time : abs, Duration;
     import std.datetime.date : DateTime;
@@ -388,7 +388,7 @@ string getCurrTimeWithOffset()
     int minutes;
     absOffset.split!("hours", "minutes")(hours, minutes);
 
-    return format!"%s.%03d%s%02d:%02d"(dt.toISOExtString(), st.fracSecs.total!"msecs", offset < Duration.zero ? "-" : "+", hours, minutes);
+    return format!"%s.%03d"(dt.toISOExtString(), st.fracSecs.total!"msecs");
 }
 
 struct Mountpoint


### PR DESCRIPTION
This makes it so that the automatic snapshots that bemgr creates don't have a time zone offset in them. It works fine when the offset is negative, but when it's positive (or zero with a +), the + causes the snapshot creation to fail, since + is not a legal character in snapshot names.

It would be nice to retain the offset, but unlike with a program that's creating regular snapshots (e.g. zfs-auto-snapshot), the snapshots that bemgr is making don't really need to worry about DST switches or other time zone changes (really, they just need unique names). So, it just seemed simpler to remove the offset than to come up with a replacement for + that was reasonably clear.